### PR TITLE
Update AssemblyAI benchmark config to u3-rt-pro sweet-spot turn settings

### DIFF
--- a/src/stt_benchmark/services.py
+++ b/src/stt_benchmark/services.py
@@ -84,8 +84,11 @@ def create_assemblyai() -> FrameProcessor:
     return AssemblyAISTTService(
         api_key=_get_env("ASSEMBLYAI_API_KEY"),
         settings=AssemblyAISTTService.Settings(
+            model="u3-rt-pro",
             end_of_turn_confidence_threshold=1.0,
-            max_turn_silence=2000,
+            min_turn_silence=50,
+            max_turn_silence=50,
+            vad_threshold=0.2,
         ),
         vad_force_turn_endpoint=True,
     )


### PR DESCRIPTION
## Summary

Sets the AssemblyAI service in the benchmark to its empirically-determined **sweet-spot** real-time config:

```python
AssemblyAISTTService.Settings(
    model="u3-rt-pro",
    end_of_turn_confidence_threshold=1.0,
    min_turn_silence=50,
    max_turn_silence=50,
    vad_threshold=0.2,
)
# vad_force_turn_endpoint=True
```

## Results

| Config | n | WER | Perfect% | TTFS p50/p95/p99 (ms) |
|---|---:|---:|---:|---|
| **vad0.2, min=max=50, eot=True** | **1000** | **1.30%** | **84.0%** | **323 / 485 / 524** |

