### PR TITLE
Make README results table the single source of truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,32 @@ For production voice agents, **P95 latency matters more than median**. Even occa
 
 > **TTFS (Time To Final Segment)** is measured from when the user stops speaking to when the final transcription segment is received. For streaming voice agents, lower TTFS means faster response times.
 
+## Contributing a Result
+
+The Results Summary table above is the **single source of truth** for the
+published numbers and the Pareto charts. Multiple people contribute, so results
+are added one row at a time rather than by rebuilding the whole table. To add
+your model's result:
+
+1. Benchmark and score it locally:
+   ```bash
+   uv run stt-benchmark run --services <key>
+   uv run stt-benchmark wer --services <key>
+   ```
+2. Upsert just your row into the table — this reads only your service's metrics
+   from your local database and leaves every other vendor's row untouched:
+   ```bash
+   uv run stt-benchmark update-readme --services <key>
+   ```
+3. Regenerate the charts from the table (read-only with respect to the README),
+   then commit `README.md` and `assets/*.png`:
+   ```bash
+   uv run python scripts/pareto-frontier-plot.py
+   ```
+
+A brand-new vendor or model also needs a registry entry first — see
+**[Adding Models](docs/adding-models.md)** for the full checklist.
+
 ## Measure TTFS for Your Service
 
 If you're using Pipecat and want TTFS latency numbers for your STT service and configuration, see **[Measuring TTFS](docs/measuring-ttfs.md)** for a quick start guide. The P95/P99 values from this tool can be used directly in Pipecat's `ttfs_p99_latency` service configuration (Pipecat 0.0.102+).

--- a/docs/adding-models.md
+++ b/docs/adding-models.md
@@ -60,43 +60,58 @@ The label's job is the generated README Model column and in-code self-descriptio
    *previous* model's entry to `is_current=False`.
 3. **`src/stt_benchmark/models.py`** — add a `ServiceName` enum value matching the
    new registry key (e.g. `ASSEMBLYAI_U3_RT_PRO = "assemblyai_u3_rt_pro"`).
-4. **`scripts/plot-config.json`** — add the new key to the `services` list to
-   feature it in the published plots and the generated README table. Labels are
-   derived automatically from `vendor` / `model_label`, so there is no name map to
-   update (add an optional `display_names` override only to override a derived
-   label). Keep the superseded key in the list too if you want both in the plot.
-5. **`README.md`** — add the new key to the Supported Services list. You do **not**
-   edit the Results Summary table by hand — it's generated between the
-   `RESULTS_TABLE` markers in step 7.
-6. **Run the benchmark** for the new entry:
+4. **`README.md`** — add the new key to the Supported Services list. You do **not**
+   hand-type the Results Summary row — step 6 writes it from your benchmark
+   database between the `RESULTS_TABLE` markers.
+5. **Run the benchmark** for the new entry:
    ```bash
    uv run stt-benchmark run --services assemblyai_u3_rt_pro
    uv run stt-benchmark ground-truth   # if not already generated for these samples
    uv run stt-benchmark wer --services assemblyai_u3_rt_pro
    ```
-7. **Regenerate plots + README table** (one command does both — the table is
-   rebuilt from the registry + database for the plot-config services, and written
-   between the `RESULTS_TABLE` markers in `README.md`):
+6. **Add your row to the README table** — a *targeted* upsert that reads only this
+   service's metrics from your local database and inserts/replaces just its row,
+   leaving every other vendor's row untouched (Vendor/Model and number formatting
+   come from the registry):
    ```bash
-   uv run python scripts/pareto-frontier-plot.py --config scripts/plot-config.json
+   uv run stt-benchmark update-readme --services assemblyai_u3_rt_pro
    ```
+7. **Regenerate the plots from the README** — the README table is the single
+   source of truth; this reads it and never rewrites it:
+   ```bash
+   uv run python scripts/pareto-frontier-plot.py
+   ```
+8. **Commit** the changed `README.md` and `assets/*.png` and open a PR. The diff
+   is your one new row plus the regenerated charts.
 
 ## Checklist: add a brand-new vendor
 
-Same as above, but the key is just the vendor name (no suffix), `is_current=True`,
-and you add it to `plot-config.json` rather than swapping an existing key.
+Same as above, but the key is just the vendor name (no suffix) and
+`is_current=True`.
+
+## Why the README table is the single source of truth
+
+More than one person contributes results, and each contributor only has raw
+benchmark runs for the vendors *they* ran locally. So the published numbers live
+in the **README Results Summary table** (between the `<!-- RESULTS_TABLE:START -->`
+/ `<!-- RESULTS_TABLE:END -->` markers), and everyone updates it the same way:
+
+- `stt-benchmark update-readme --services <key>` upserts **one row at a time**
+  from your local database — a targeted insert/replace keyed by
+  `(vendor, model_label)`. It never rebuilds the whole table, so it can't wipe a
+  row you don't have locally. Rows for services with no registry entry are
+  preserved too.
+- `scripts/pareto-frontier-plot.py` **reads** the table and renders every row
+  into the Pareto charts. It is read-only with respect to the README, so the
+  charts always match the published numbers and regenerating them is safe.
 
 ## Where the metadata lives
 
 - `vendor` / `model_label` / `is_current` live on `ServiceDefinition` in
-  `services.py`, so each entry is self-describing. Plot/report labels are derived
-  from these via `get_display_names()` — there is no separate name map to maintain.
-- `plot-config.json` decides **which** models appear in the published plots (its
-  `services` list), plus optional per-service `display_names` overrides. Keeping a
-  model out of the plots does not remove it from the registry — it stays runnable.
-- The README **Results Summary table** is generated, not hand-edited:
-  `scripts/pareto-frontier-plot.py` rebuilds it from the registry (Vendor =
-  `vendor`, Model = `model_label`) and the results database for the same
-  plot-config services, and writes it between the `<!-- RESULTS_TABLE:START -->` /
-  `<!-- RESULTS_TABLE:END -->` markers in `README.md`. If those markers are
-  missing it falls back to writing `assets/results-table.md`.
+  `services.py`, so each entry is self-describing. `update-readme` uses them for
+  the Vendor/Model columns and the table sort order (vendor, current model first).
+  Plot labels are derived from `vendor` / `model_label` for the chart legend.
+- `scripts/plot-config.json` holds optional plot tunables (`latency`, `output`,
+  and per-label `display_names` overrides). It no longer selects which models
+  appear — the plot renders whatever rows are in the README table. Use
+  `pareto-frontier-plot.py -s <label> ...` for an ad-hoc subset.

--- a/scripts/pareto-frontier-plot.py
+++ b/scripts/pareto-frontier-plot.py
@@ -2,13 +2,14 @@
 """Generate a Pareto frontier plot of TTFS vs Semantic WER for STT services."""
 
 import argparse
-import asyncio
 import json
 import sys
 from pathlib import Path
 
 # Add parent to path for imports when running as script
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from stt_benchmark.reporting.readme_table import METRIC_KEYS, parse_table_rows  # noqa: E402
 
 LATENCY_METRICS = {
     "median": {"key": "ttfb_median", "label": "TTFS Median", "suffix": ""},
@@ -17,49 +18,11 @@ LATENCY_METRICS = {
 }
 
 
-def get_data_from_db():
-    """Fetch service metrics from the database."""
-    from stt_benchmark.storage.database import Database
-
-    async def fetch():
-        db = Database()
-        await db.initialize()
-
-        services = await db.get_services_with_results()
-        data = {}
-
-        for service_name, model_name in services:
-            transcript_stats = await db.get_service_transcript_stats(service_name, model_name)
-            wer_summary = await db.get_service_summary(service_name, model_name)
-
-            if transcript_stats and wer_summary:
-                sample_count = wer_summary["sample_count"]
-                perfect_pct = (
-                    wer_summary["perfect_count"] / sample_count * 100 if sample_count else 0.0
-                )
-                data[service_name.value] = {
-                    "ttfb_median": transcript_stats["ttfb_median"] * 1000,  # Convert to ms
-                    "ttfb_p95": transcript_stats["ttfb_p95"] * 1000,
-                    "ttfb_p99": transcript_stats["ttfb_p99"] * 1000,
-                    "pooled_wer": wer_summary["pooled_wer"] * 100,  # Convert to %
-                    # Extra fields used by the README table (not the plot):
-                    "success_rate": transcript_stats["success_rate"] * 100,
-                    "perfect_pct": perfect_pct,
-                    "wer_mean": wer_summary["wer_mean"] * 100,
-                }
-
-        await db.close()
-        return data
-
-    return asyncio.run(fetch())
-
-
 def plot_pareto_frontier(
     data: dict,
     latency_metric: str = "median",
     output_path: str = "stt_pareto_frontier.png",
     show: bool = False,
-    capitalize_labels: bool = True,
 ):
     """Generate the TTFS vs WER scatter plot with Pareto frontier annotation."""
     try:
@@ -219,8 +182,8 @@ def plot_pareto_frontier(
         # List Pareto optimal services with stats
         service_strs = []
         for name, ttfb, wer in pareto_optimal:
-            label = name.capitalize() if capitalize_labels else name
-            service_strs.append(f"{label}: {ttfb:.0f}ms, WER {wer:.2f}%")
+            # README labels are already display-ready; use them verbatim.
+            service_strs.append(f"{name}: {ttfb:.0f}ms, WER {wer:.2f}%")
 
         # Display services in a wrapped format
         services_text = "    ".join(service_strs)
@@ -306,78 +269,15 @@ def filter_services(data: dict, service_names: list[str]) -> dict:
     return filtered
 
 
-def generate_markdown_table(data: dict) -> str:
-    """Build the README "Results Summary" table from registry + DB metrics.
-
-    ``data`` is keyed by service key (i.e. before display-name remapping). The
-    Vendor and Model columns come from the registry (``vendor`` / ``model_label``)
-    so they never drift from the services config; metrics come from the database.
-    Rows are grouped by vendor, current model first. Only services with complete
-    metrics appear (a configured-but-not-yet-benchmarked model is skipped).
-    """
-    from stt_benchmark.services import STT_SERVICES
-
-    rows = []
-    for key, metrics in data.items():
-        definition = STT_SERVICES.get(key)
-        if definition is None:
-            continue
-        rows.append((definition, metrics))
-
-    # Group by vendor, current model first, then by model label.
-    rows.sort(key=lambda r: (r[0].vendor.lower(), not r[0].is_current, r[0].model_label.lower()))
-
-    lines = [
-        "| Vendor | Model | Transcripts | Perfect | WER Mean | Pooled WER "
-        "| TTFS Median | TTFS P95 | TTFS P99 |",
-        "|--------|-------|-------------|---------|----------|------------"
-        "|-------------|----------|----------|",
-    ]
-    for definition, m in rows:
-        lines.append(
-            f"| {definition.vendor} | {definition.model_label} "
-            f"| {m['success_rate']:.1f}% | {m['perfect_pct']:.1f}% "
-            f"| {m['wer_mean']:.2f}% | {m['pooled_wer']:.2f}% "
-            f"| {m['ttfb_median']:.0f}ms | {m['ttfb_p95']:.0f}ms | {m['ttfb_p99']:.0f}ms |"
-        )
-    return "\n".join(lines)
-
-
-README_TABLE_START = "<!-- RESULTS_TABLE:START -->"
-README_TABLE_END = "<!-- RESULTS_TABLE:END -->"
-
-
-def update_readme_table(table_md: str, readme_path: Path) -> bool:
-    """Replace the results table in README.md between the marker comments.
-
-    Returns True if the README was updated, False if the markers were not found
-    (in which case the caller should fall back to writing a standalone file).
-    """
-    if not readme_path.exists():
-        return False
-    content = readme_path.read_text()
-    if README_TABLE_START not in content or README_TABLE_END not in content:
-        return False
-
-    before, _, rest = content.partition(README_TABLE_START)
-    _, _, after = rest.partition(README_TABLE_END)
-    new_content = f"{before}{README_TABLE_START}\n{table_md}\n{README_TABLE_END}{after}"
-    readme_path.write_text(new_content)
-    return True
-
-
 def get_data_from_readme(readme_path: Path) -> dict:
-    """Parse the "Results Summary" table from README.md as the data source.
+    """Build plot data from the README "Results Summary" table.
 
-    Used when the canonical multi-vendor metrics live only in the committed
-    README table (we don't have raw benchmark runs for every vendor locally).
-    The table between the RESULTS_TABLE markers is treated as the single source
-    of truth, so the regenerated Pareto charts always match the published
-    numbers. Returns the same dict shape as ``get_data_from_db`` (keyed by a
-    display label, values in ms / %).
+    The table between the RESULTS_TABLE markers is the single source of truth, so
+    the rendered Pareto charts always match the published numbers. Returns a dict
+    keyed by a display label, with values in ms / %.
 
     Point labels are the vendor name when a vendor has a single row, or
-    ``"{vendor} {model}"`` when a vendor ships multiple models (so they don't
+    ``"{vendor} {model}"`` when a vendor ships multiple rows (so they don't
     collide on the chart).
     """
     from collections import Counter
@@ -386,64 +286,16 @@ def get_data_from_readme(readme_path: Path) -> dict:
         print(f"README not found: {readme_path}")
         sys.exit(1)
 
-    content = readme_path.read_text()
-    if README_TABLE_START in content and README_TABLE_END in content:
-        _, _, rest = content.partition(README_TABLE_START)
-        table_block, _, _ = rest.partition(README_TABLE_END)
-    else:
-        # Fall back to scanning the whole file for pipe-delimited rows.
-        table_block = content
-
-    def _num(cell: str) -> float:
-        return float(cell.replace("%", "").replace("ms", "").strip())
-
-    rows = []
-    for line in table_block.splitlines():
-        line = line.strip()
-        if not line.startswith("|"):
-            continue
-        cells = [c.strip() for c in line.strip("|").split("|")]
-        if len(cells) < 9:
-            continue
-        vendor, model = cells[0], cells[1]
-        # Skip the header row and the |---|---| separator row.
-        if vendor.lower() == "vendor" or set(vendor) <= set("-: "):
-            continue
-        try:
-            rows.append(
-                {
-                    "vendor": vendor,
-                    "model": model,
-                    "success_rate": _num(cells[2]),
-                    "perfect_pct": _num(cells[3]),
-                    "wer_mean": _num(cells[4]),
-                    "pooled_wer": _num(cells[5]),
-                    "ttfb_median": _num(cells[6]),
-                    "ttfb_p95": _num(cells[7]),
-                    "ttfb_p99": _num(cells[8]),
-                }
-            )
-        except ValueError:
-            # A row whose metric cells aren't numeric isn't a data row; skip it.
-            continue
+    rows = parse_table_rows(readme_path.read_text())
 
     vendor_counts = Counter(r["vendor"] for r in rows)
-    metric_keys = (
-        "ttfb_median",
-        "ttfb_p95",
-        "ttfb_p99",
-        "pooled_wer",
-        "success_rate",
-        "perfect_pct",
-        "wer_mean",
-    )
     data = {}
     for r in rows:
         if vendor_counts[r["vendor"]] > 1 and r["model"] and r["model"].upper() != "N/A":
             label = f"{r['vendor']} {r['model']}"
         else:
             label = r["vendor"]
-        data[label] = {k: r[k] for k in metric_keys}
+        data[label] = {k: r[k] for k in METRIC_KEYS}
     return data
 
 
@@ -479,14 +331,12 @@ def main():
         help="Path to a JSON config file with plot settings",
     )
     parser.add_argument(
-        "--from-readme",
-        nargs="?",
-        const="README.md",
-        default=None,
+        "--readme",
+        default="README.md",
         metavar="README_PATH",
-        help="Use the README results table as the data source instead of the database "
-        "(default path: README.md, resolved relative to the repo root). Skips DB access "
-        "and README table regeneration — the README is treated as the source of truth.",
+        help="Path to the README whose results table is the data source "
+        "(default: README.md, resolved relative to the repo root). The README is "
+        "the single source of truth; this script never writes to it.",
     )
     parser.add_argument(
         "--show",
@@ -509,71 +359,30 @@ def main():
     display_names = file_config.get("display_names", {})
     show = args.show if args.show is not None else file_config.get("show", False)
 
-    # README-derived labels are already display-ready; DB keys are lowercase
-    # service names that the bottom panel capitalizes.
-    capitalize_labels = args.from_readme is None
+    # The README results table is the single source of truth for the published
+    # numbers; plots are always rendered from it (never from the DB), so this
+    # script never modifies the README. To add/update a row, use
+    # `stt-benchmark update-readme`.
+    readme_path = Path(args.readme)
+    if not readme_path.is_absolute() and not readme_path.exists():
+        readme_path = Path(__file__).parent.parent / args.readme
+    print(f"Reading metrics from README table: {readme_path}")
+    data = get_data_from_readme(readme_path)
 
-    if args.from_readme is not None:
-        # README is the source of truth: read the published table as-is and do
-        # NOT regenerate it or remap labels from the registry.
-        readme_path = Path(args.from_readme)
-        if not readme_path.is_absolute() and not readme_path.exists():
-            readme_path = Path(__file__).parent.parent / args.from_readme
-        print(f"Reading metrics from README table: {readme_path}")
-        data = get_data_from_readme(readme_path)
+    if not data:
+        print("No data rows parsed from the README table. Nothing to plot.")
+        sys.exit(1)
 
+    # Filter to requested services (case-insensitive match on the label)
+    if services:
+        data = filter_services(data, services)
         if not data:
-            print("No data rows parsed from the README table. Nothing to plot.")
+            print("No matching services found. Nothing to plot.")
             sys.exit(1)
 
-        # Filter to requested services (case-insensitive match on the label)
-        if services:
-            data = filter_services(data, services)
-            if not data:
-                print("No matching services found. Nothing to plot.")
-                sys.exit(1)
-    else:
-        print("Fetching data from database...")
-        data = get_data_from_db()
-
-        if not data:
-            print("No data found. Run benchmarks and WER calculation first.")
-            sys.exit(1)
-
-        # Filter to requested services
-        if services:
-            data = filter_services(data, services)
-            if not data:
-                print("No matching services found. Nothing to plot.")
-                sys.exit(1)
-
-        # Generate the README results table from the same (plot-config) services,
-        # using registry labels + DB metrics. Do this before display-name remapping
-        # so we still have service keys to look up vendor/model_label.
-        table_md = generate_markdown_table(data)
-        readme_path = Path(__file__).parent.parent / "README.md"
-        if update_readme_table(table_md, readme_path):
-            print(f"\nUpdated results table in: {readme_path}\n")
-        else:
-            out = Path(output)
-            table_dir = out if (out.is_dir() or output.endswith("/")) else out.parent
-            table_dir.mkdir(parents=True, exist_ok=True)
-            table_file = table_dir / "results-table.md"
-            table_file.write_text(table_md + "\n")
-            print(
-                f"\nREADME markers not found; wrote table to: {table_file}\n"
-                f"(add {README_TABLE_START} / {README_TABLE_END} around the table in "
-                f"README.md to auto-update it)\n"
-            )
-        print(table_md)
-        print()
-
-        # Derive labels from registry metadata (vendor / model_label). Any
-        # display_names in the config are optional per-service overrides.
-        from stt_benchmark.services import get_display_names
-
-        labels = {**get_display_names(list(data.keys())), **display_names}
-        data = apply_display_names(data, labels)
+    # Optional per-label display-name overrides from the config file.
+    if display_names:
+        data = apply_display_names(data, display_names)
 
     print(f"Found {len(data)} services with complete metrics")
     for name, metrics in sorted(data.items()):
@@ -608,7 +417,7 @@ def main():
             suffix = LATENCY_METRICS[metric]["suffix"]
             plot_output = output_path / f"{default_basename}{suffix}.png"
             print(f"\nGenerating {LATENCY_METRICS[metric]['label']} plot...")
-            plot_pareto_frontier(data, metric, str(plot_output), show, capitalize_labels)
+            plot_pareto_frontier(data, metric, str(plot_output), show)
     else:
         for metric in metrics_to_plot:
             suffix = LATENCY_METRICS[metric]["suffix"]
@@ -617,7 +426,7 @@ def main():
             else:
                 plot_output = output_path
             print(f"\nGenerating {LATENCY_METRICS[metric]['label']} plot...")
-            plot_pareto_frontier(data, metric, str(plot_output), show, capitalize_labels)
+            plot_pareto_frontier(data, metric, str(plot_output), show)
 
 
 if __name__ == "__main__":

--- a/scripts/plot-config.json
+++ b/scripts/plot-config.json
@@ -1,21 +1,4 @@
 {
-  "services": [
-    "assemblyai",
-    "assemblyai_u3_rt_pro",
-    "aws",
-    "azure",
-    "cartesia",
-    "cartesia_ink2",
-    "deepgram",
-    "elevenlabs",
-    "google",
-    "gradium",
-    "mistral",
-    "openai_realtime",
-    "smallest",
-    "soniox",
-    "speechmatics"
-  ],
   "latency": ["median", "p95"],
   "output": "assets/"
 }

--- a/src/stt_benchmark/cli/main.py
+++ b/src/stt_benchmark/cli/main.py
@@ -7,6 +7,7 @@ from stt_benchmark.cli.download import app as download_app
 from stt_benchmark.cli.export import app as export_app
 from stt_benchmark.cli.ground_truth import app as ground_truth_app
 from stt_benchmark.cli.report import app as report_app
+from stt_benchmark.cli.update_readme import app as update_readme_app
 from stt_benchmark.cli.wer import app as wer_app
 
 app = typer.Typer(
@@ -22,6 +23,11 @@ app.add_typer(ground_truth_app, name="ground-truth", help="Generate ground truth
 app.add_typer(wer_app, name="wer", help="Calculate semantic WER metrics")
 app.add_typer(report_app, name="report", help="Generate reports and compare services")
 app.add_typer(export_app, name="export", help="Export data for a specific service")
+app.add_typer(
+    update_readme_app,
+    name="update-readme",
+    help="Add/update a service's row in the README results table",
+)
 
 
 @app.callback()

--- a/src/stt_benchmark/cli/update_readme.py
+++ b/src/stt_benchmark/cli/update_readme.py
@@ -1,0 +1,147 @@
+"""CLI command for upserting service rows into the README results table.
+
+The README "Results Summary" table is the single source of truth for the
+published benchmark numbers and the Pareto plots. This command reads a service's
+metrics from your local benchmark database and writes *just that row* into the
+table, leaving every other row untouched — so multiple contributors can each add
+their own result without clobbering anyone else's.
+"""
+
+import asyncio
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from stt_benchmark.config import get_config
+from stt_benchmark.models import ServiceName
+from stt_benchmark.reporting.readme_table import upsert_readme_rows
+from stt_benchmark.services import STT_SERVICES, parse_services_arg
+from stt_benchmark.storage.database import Database
+
+app = typer.Typer()
+console = Console()
+
+
+def _repo_readme() -> Path:
+    """Repo-root README.md (src/stt_benchmark/cli/update_readme.py -> parents[3])."""
+    return Path(__file__).resolve().parents[3] / "README.md"
+
+
+@app.callback(invoke_without_command=True)
+def update_readme(
+    services: str = typer.Option(
+        ...,
+        "--services",
+        "-s",
+        help="Comma-separated service keys to add/update (e.g. deepgram,nvidia)",
+    ),
+    readme: Path = typer.Option(
+        None,
+        "--readme",
+        help="Path to README.md (default: repo README.md)",
+    ),
+    test: bool = typer.Option(
+        False,
+        "--test",
+        "-t",
+        help="Use test database (test_results.db) instead of main database",
+    ),
+):
+    """Insert or update one row per service in the README results table.
+
+    Reads the named services' metrics from your local benchmark database and
+    upserts just those rows between the RESULTS_TABLE markers in README.md,
+    leaving every other row byte-identical. Regenerate the plots afterwards with
+    ``uv run python scripts/pareto-frontier-plot.py`` (which reads the README).
+
+    The services must already be benchmarked and scored locally
+    (``stt-benchmark run`` then ``stt-benchmark wer``).
+    """
+    console.print("\n[bold blue]STT Benchmark - Update README table[/bold blue]\n")
+
+    try:
+        service_list = parse_services_arg(services)
+    except ValueError as e:
+        console.print(f"[red]{e}[/red]")
+        raise typer.Exit(1) from None
+
+    readme_path = readme or _repo_readme()
+    if not readme_path.exists():
+        console.print(f"[red]README not found: {readme_path}[/red]")
+        raise typer.Exit(1)
+
+    db_path = None
+    if test:
+        db_path = get_config().data_dir / "test_results.db"
+        console.print("[yellow]Using test database[/yellow]\n")
+
+    rows, missing = asyncio.run(_fetch_rows(service_list, db_path))
+
+    for key in missing:
+        console.print(
+            f"[yellow]No benchmark/WER results for '{key}' — run "
+            f"'stt-benchmark run -s {key}' and 'stt-benchmark wer -s {key}' first. "
+            f"Skipping.[/yellow]"
+        )
+
+    if not rows:
+        console.print("\n[yellow]Nothing to update.[/yellow]")
+        raise typer.Exit(1)
+
+    written = upsert_readme_rows(readme_path, rows)
+    console.print(f"\n[green]Updated {len(written)} row(s) in {readme_path}:[/green]")
+    for label in written:
+        console.print(f"  • {label}")
+    console.print(
+        "\n[dim]Now regenerate the plots from the README:[/dim] "
+        "uv run python scripts/pareto-frontier-plot.py"
+    )
+
+
+async def _fetch_rows(
+    service_list: list[ServiceName], db_path: Path | None
+) -> tuple[list[tuple], list[str]]:
+    """Fetch ``(definition, metrics)`` rows for services that have local results.
+
+    Mirrors the DB → metrics conversion the plot script used to do: TTFB stats
+    and the WER summary, converted to ms / %. Returns ``(rows, missing)`` where
+    ``missing`` lists requested service keys with no benchmark/WER results yet.
+    """
+    db = Database(db_path=db_path)
+    await db.initialize()
+    try:
+        model_by_service = {
+            name.value: model for name, model in await db.get_services_with_results()
+        }
+
+        rows: list[tuple] = []
+        found: set[str] = set()
+        for service in service_list:
+            key = service.value
+            if key not in model_by_service:
+                continue
+            model_name = model_by_service[key]
+            stats = await db.get_service_transcript_stats(service, model_name)
+            summary = await db.get_service_summary(service, model_name)
+            if not stats or not summary:
+                continue
+
+            sample_count = summary["sample_count"]
+            perfect_pct = summary["perfect_count"] / sample_count * 100 if sample_count else 0.0
+            metrics = {
+                "ttfb_median": stats["ttfb_median"] * 1000,  # s -> ms
+                "ttfb_p95": stats["ttfb_p95"] * 1000,
+                "ttfb_p99": stats["ttfb_p99"] * 1000,
+                "pooled_wer": summary["pooled_wer"] * 100,  # fraction -> %
+                "success_rate": stats["success_rate"] * 100,
+                "perfect_pct": perfect_pct,
+                "wer_mean": summary["wer_mean"] * 100,
+            }
+            rows.append((STT_SERVICES[key], metrics))
+            found.add(key)
+    finally:
+        await db.close()
+
+    missing = [s.value for s in service_list if s.value not in found]
+    return rows, missing

--- a/src/stt_benchmark/reporting/__init__.py
+++ b/src/stt_benchmark/reporting/__init__.py
@@ -1,0 +1,1 @@
+"""Reporting helpers (README results table, etc.)."""

--- a/src/stt_benchmark/reporting/readme_table.py
+++ b/src/stt_benchmark/reporting/readme_table.py
@@ -1,0 +1,190 @@
+"""Helpers for the README "Results Summary" table.
+
+The table between the ``RESULTS_TABLE`` marker comments in ``README.md`` is the
+single source of truth for the published benchmark numbers. This module is the
+one place that knows that table's column layout — it formats rows, parses the
+table back into data, and upserts individual rows.
+
+It is pure string/registry logic with **no database dependency** (the registry
+import is lazy), so both the plot script — which *reads* the table to render the
+Pareto charts — and the ``stt-benchmark update-readme`` command — which *writes*
+a contributor's row into it — can share exactly one definition of the format.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from stt_benchmark.services import ServiceDefinition
+
+README_TABLE_START = "<!-- RESULTS_TABLE:START -->"
+README_TABLE_END = "<!-- RESULTS_TABLE:END -->"
+
+# Header + separator lines. format_row() emits data rows beneath these.
+TABLE_HEADER = (
+    "| Vendor | Model | Transcripts | Perfect | WER Mean | Pooled WER "
+    "| TTFS Median | TTFS P95 | TTFS P99 |",
+    "|--------|-------|-------------|---------|----------|------------"
+    "|-------------|----------|----------|",
+)
+
+# Metric dict keys carried for each service, in display units (ms / %).
+METRIC_KEYS = (
+    "ttfb_median",
+    "ttfb_p95",
+    "ttfb_p99",
+    "pooled_wer",
+    "success_rate",
+    "perfect_pct",
+    "wer_mean",
+)
+
+
+def format_row(vendor: str, model_label: str, m: dict) -> str:
+    """Render one ``| ... |`` data row. ``m`` holds the METRIC_KEYS in ms / %."""
+    return (
+        f"| {vendor} | {model_label} "
+        f"| {m['success_rate']:.1f}% | {m['perfect_pct']:.1f}% "
+        f"| {m['wer_mean']:.2f}% | {m['pooled_wer']:.2f}% "
+        f"| {m['ttfb_median']:.0f}ms | {m['ttfb_p95']:.0f}ms | {m['ttfb_p99']:.0f}ms |"
+    )
+
+
+def sort_key(vendor: str, is_current: bool, model_label: str) -> tuple:
+    """Table ordering: by vendor, current model first, then model label."""
+    return (vendor.lower(), not is_current, model_label.lower())
+
+
+def build_table(rows: list[tuple[ServiceDefinition, dict]]) -> str:
+    """Build the full table markdown from ``(definition, metrics)`` rows.
+
+    Vendor/Model come from the registry definition (so they never drift from the
+    services config); metrics come from the caller. Rows are grouped by vendor,
+    current model first.
+    """
+    ordered = sorted(rows, key=lambda r: sort_key(r[0].vendor, r[0].is_current, r[0].model_label))
+    lines = [*TABLE_HEADER]
+    for definition, m in ordered:
+        lines.append(format_row(definition.vendor, definition.model_label, m))
+    return "\n".join(lines)
+
+
+def parse_table_rows(content: str) -> list[dict]:
+    """Parse the README results table into per-row dicts.
+
+    Reads the block between the ``RESULTS_TABLE`` markers when present, otherwise
+    scans the whole text for pipe-delimited rows. The header row, the
+    ``|---|---|`` separator, and any row whose metric cells aren't numeric are
+    skipped. Each returned dict has ``vendor``, ``model``, and the METRIC_KEYS
+    (values in ms / %).
+    """
+    if README_TABLE_START in content and README_TABLE_END in content:
+        _, _, rest = content.partition(README_TABLE_START)
+        block, _, _ = rest.partition(README_TABLE_END)
+    else:
+        block = content
+
+    def _num(cell: str) -> float:
+        return float(cell.replace("%", "").replace("ms", "").strip())
+
+    rows: list[dict] = []
+    for line in block.splitlines():
+        line = line.strip()
+        if not line.startswith("|"):
+            continue
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if len(cells) < 9:
+            continue
+        vendor, model = cells[0], cells[1]
+        # Skip the header row and the |---|---| separator row.
+        if vendor.lower() == "vendor" or set(vendor) <= set("-: "):
+            continue
+        try:
+            rows.append(
+                {
+                    "vendor": vendor,
+                    "model": model,
+                    "success_rate": _num(cells[2]),
+                    "perfect_pct": _num(cells[3]),
+                    "wer_mean": _num(cells[4]),
+                    "pooled_wer": _num(cells[5]),
+                    "ttfb_median": _num(cells[6]),
+                    "ttfb_p95": _num(cells[7]),
+                    "ttfb_p99": _num(cells[8]),
+                }
+            )
+        except ValueError:
+            # A row whose metric cells aren't numeric isn't a data row; skip it.
+            continue
+    return rows
+
+
+def update_readme_table(table_md: str, readme_path: Path) -> bool:
+    """Replace the results table in README.md between the marker comments.
+
+    Returns True if the README was updated, False if the file or markers are
+    missing.
+    """
+    if not readme_path.exists():
+        return False
+    content = readme_path.read_text()
+    if README_TABLE_START not in content or README_TABLE_END not in content:
+        return False
+
+    before, _, rest = content.partition(README_TABLE_START)
+    _, _, after = rest.partition(README_TABLE_END)
+    new_content = f"{before}{README_TABLE_START}\n{table_md}\n{README_TABLE_END}{after}"
+    readme_path.write_text(new_content)
+    return True
+
+
+def upsert_readme_rows(
+    readme_path: Path, new_rows: list[tuple[ServiceDefinition, dict]]
+) -> list[str]:
+    """Insert or replace individual rows in the README results table.
+
+    Each entry in ``new_rows`` is ``(definition, metrics)``. A new row is matched
+    to an existing one by ``(vendor, model_label)`` (case-insensitive); matches
+    are replaced in place and brand-new entries are appended. Every other row is
+    left exactly as it was — this is a *targeted* update, never a full rebuild,
+    so rows contributed by others (or hand-added rows with no registry entry) are
+    preserved. The merged set is re-sorted with the same key as ``build_table``.
+
+    Returns the ``"Vendor — Model"`` labels that were written.
+    """
+    if not readme_path.exists():
+        raise FileNotFoundError(readme_path)
+    content = readme_path.read_text()
+    if README_TABLE_START not in content or README_TABLE_END not in content:
+        raise ValueError(f"RESULTS_TABLE markers not found in {readme_path}; cannot upsert rows.")
+
+    # Existing rows, keyed by (vendor, model) for replace-or-append.
+    by_key = {(r["vendor"].lower(), r["model"].lower()): r for r in parse_table_rows(content)}
+
+    written: list[str] = []
+    for definition, m in new_rows:
+        row = {"vendor": definition.vendor, "model": definition.model_label}
+        row.update({k: m[k] for k in METRIC_KEYS})
+        by_key[(definition.vendor.lower(), definition.model_label.lower())] = row
+        written.append(f"{definition.vendor} — {definition.model_label}")
+
+    # Re-sort the merged set. Look up is_current from the registry where a row
+    # maps to a known service; default True for foreign/manually-added rows.
+    from stt_benchmark.services import STT_SERVICES
+
+    is_current = {
+        (d.vendor.lower(), d.model_label.lower()): d.is_current for d in STT_SERVICES.values()
+    }
+    merged = sorted(
+        by_key.values(),
+        key=lambda r: sort_key(
+            r["vendor"], is_current.get((r["vendor"].lower(), r["model"].lower()), True), r["model"]
+        ),
+    )
+
+    body = "\n".join([*TABLE_HEADER, *(format_row(r["vendor"], r["model"], r) for r in merged)])
+    update_readme_table(body, readme_path)
+    return written

--- a/tests/test_readme_table.py
+++ b/tests/test_readme_table.py
@@ -1,0 +1,123 @@
+"""Tests for the README results-table helpers (single source of truth)."""
+
+from types import SimpleNamespace
+
+from stt_benchmark.reporting.readme_table import (
+    README_TABLE_END,
+    README_TABLE_START,
+    format_row,
+    parse_table_rows,
+    upsert_readme_rows,
+)
+
+
+def _metrics(**overrides):
+    base = {
+        "success_rate": 99.8,
+        "perfect_pct": 76.5,
+        "wer_mean": 1.71,
+        "pooled_wer": 1.62,
+        "ttfb_median": 247.0,
+        "ttfb_p95": 298.0,
+        "ttfb_p99": 326.0,
+    }
+    base.update(overrides)
+    return base
+
+
+def _readme(rows: str) -> str:
+    return (
+        "# Title\n\nSome intro.\n\n"
+        f"{README_TABLE_START}\n"
+        "| Vendor | Model | Transcripts | Perfect | WER Mean | Pooled WER "
+        "| TTFS Median | TTFS P95 | TTFS P99 |\n"
+        "|--------|-------|-------------|---------|----------|------------"
+        "|-------------|----------|----------|\n"
+        f"{rows}"
+        f"{README_TABLE_END}\n\n## After\n"
+    )
+
+
+def test_format_row_units_and_precision():
+    row = format_row("Deepgram", "nova-3-general", _metrics())
+    assert row == (
+        "| Deepgram | nova-3-general | 99.8% | 76.5% | 1.71% | 1.62% | 247ms | 298ms | 326ms |"
+    )
+
+
+def test_parse_table_rows_skips_header_and_separator():
+    content = _readme(
+        "| Deepgram | nova-3-general | 99.8% | 76.5% | 1.71% | 1.62% | 247ms | 298ms | 326ms |\n"
+        "| AWS | N/A | 100.0% | 77.4% | 1.68% | 1.75% | 1136ms | 1527ms | 1897ms |\n"
+    )
+    rows = parse_table_rows(content)
+    assert [r["vendor"] for r in rows] == ["Deepgram", "AWS"]
+    assert rows[0]["ttfb_p95"] == 298.0
+    assert rows[1]["model"] == "N/A"
+
+
+def test_parse_format_round_trips():
+    line = "| Deepgram | nova-3-general | 99.8% | 76.5% | 1.71% | 1.62% | 247ms | 298ms | 326ms |"
+    [parsed] = parse_table_rows(_readme(line + "\n"))
+    assert format_row(parsed["vendor"], parsed["model"], parsed) == line
+
+
+def test_upsert_inserts_in_sorted_position(tmp_path):
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        _readme(
+            "| AWS | N/A | 100.0% | 77.4% | 1.68% | 1.75% | 1136ms | 1527ms | 1897ms |\n"
+            "| Soniox | stt-rt-v4 | 99.8% | 84.1% | 1.25% | 1.29% | 249ms | 281ms | 310ms |\n"
+        )
+    )
+    defn = SimpleNamespace(vendor="Deepgram", model_label="nova-3-general")
+    written = upsert_readme_rows(readme, [(defn, _metrics())])
+
+    assert written == ["Deepgram — nova-3-general"]
+    vendors = [r["vendor"] for r in parse_table_rows(readme.read_text())]
+    # Deepgram sorts between AWS and Soniox.
+    assert vendors == ["AWS", "Deepgram", "Soniox"]
+
+
+def test_upsert_replaces_existing_row(tmp_path):
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        _readme(
+            "| Deepgram | nova-3-general | 99.8% | 76.5% | 1.71% | 1.62% | 247ms | 298ms | 326ms |\n"
+        )
+    )
+    defn = SimpleNamespace(vendor="Deepgram", model_label="nova-3-general")
+    upsert_readme_rows(readme, [(defn, _metrics(ttfb_median=999.0, pooled_wer=2.22))])
+
+    rows = parse_table_rows(readme.read_text())
+    assert len(rows) == 1
+    assert rows[0]["ttfb_median"] == 999.0
+    assert rows[0]["pooled_wer"] == 2.22
+
+
+def test_upsert_preserves_foreign_rows(tmp_path):
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        _readme(
+            "| ContributorCo | special-model | 95.0% | 50.0% | 5.00% | 6.00% "
+            "| 500ms | 600ms | 700ms |\n"
+        )
+    )
+    defn = SimpleNamespace(vendor="Deepgram", model_label="nova-3-general")
+    upsert_readme_rows(readme, [(defn, _metrics())])
+
+    vendors = {r["vendor"] for r in parse_table_rows(readme.read_text())}
+    assert "ContributorCo" in vendors  # foreign row not dropped
+    assert "Deepgram" in vendors
+
+
+def test_upsert_is_idempotent(tmp_path):
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        _readme("| AWS | N/A | 100.0% | 77.4% | 1.68% | 1.75% | 1136ms | 1527ms | 1897ms |\n")
+    )
+    defn = SimpleNamespace(vendor="Deepgram", model_label="nova-3-general")
+    upsert_readme_rows(readme, [(defn, _metrics())])
+    once = readme.read_text()
+    upsert_readme_rows(readme, [(defn, _metrics())])
+    assert readme.read_text() == once


### PR DESCRIPTION
## Summary

Treat the README **Results Summary table** as the single source of truth for published benchmark numbers, and decouple *contributing data* from *rendering charts* — so multiple people can each add their own result without clobbering anyone else's.

- **Add `stt-benchmark update-readme --services <key>`** — a targeted upsert that reads only the named service's metrics from your local DB and inserts/replaces just its row (keyed by `vendor`+`model_label`), leaving every other row untouched. Skips + warns for services with no local benchmark/WER results.
- **Slim `pareto-frontier-plot.py`** to read the README table as its only data source and render the charts. It no longer touches the DB or rewrites the table, so regenerating plots is safe.
- **New shared `stt_benchmark/reporting/readme_table.py`** — the one place that knows the table format (format/parse/sort/upsert), DB-free, used by both the CLI command and the plot script.
- Update `docs/adding-models.md` and `README.md` to the new workflow (benchmark → `update-readme` → regenerate plots).

### Why

Previously the plot script's default mode rebuilt the *entire* README table from the local DB. With multiple contributors, whoever ran it would wipe every row not present in their own database (e.g. drop another contributor's just-added rows).

## Breaking Changes

- `pareto-frontier-plot.py` no longer reads the database or writes the README table — it only renders charts from the README. The old `--from-readme` flag is now `--readme PATH` (README is always the source).
- The README results table is no longer regenerated by the plot script; add/update rows with `stt-benchmark update-readme` instead.
- Removed the `services` list from `scripts/plot-config.json` — the README rows are now the curation. The plot renders all README rows; use `-s <label>` for an ad-hoc subset.

## Testing

- `uv run pytest tests/test_readme_table.py` — format/parse round-trip and upsert insert / replace / re-sort / preserve-foreign-row behavior (7 tests).
- Targeted upsert against a real DB: `update-readme --services deepgram` re-renders the published row byte-identically (zero diff) and leaves all other rows untouched; running twice is idempotent.
- `uv run python scripts/pareto-frontier-plot.py` renders all README rows and leaves `README.md` unchanged.