### PR TITLE
Persist benchmark    results incrementally (crash-safe)

### DIFF
--- a/src/stt_benchmark/cli/benchmark.py
+++ b/src/stt_benchmark/cli/benchmark.py
@@ -176,12 +176,10 @@ def run_benchmark(
                         service_name,
                         model=model,
                         progress_callback=callback,
+                        db=db,
                     )
 
                     progress.update(task, completed=len(pending))
-
-                # Save results
-                await db.insert_results_batch(results)
 
                 # Compute and display statistics
                 successful = len([r for r in results if not r.error])

--- a/src/stt_benchmark/pipeline/benchmark_runner.py
+++ b/src/stt_benchmark/pipeline/benchmark_runner.py
@@ -16,6 +16,8 @@ from pipecat.workers.runner import WorkerRunner
 if TYPE_CHECKING:
     import aiohttp
 
+    from stt_benchmark.storage.database import Database
+
 from stt_benchmark.config import get_config
 from stt_benchmark.models import AudioSample, BenchmarkResult, ServiceName
 from stt_benchmark.observers.metrics_collector import MetricsCollectorObserver
@@ -258,6 +260,7 @@ class BenchmarkRunner:
         self,
         samples: list[AudioSample],
         service_name: ServiceName,
+        db: "Database",
         model: str | None = None,
         progress_callback: Callable | None = None,
     ) -> list[BenchmarkResult]:
@@ -266,6 +269,8 @@ class BenchmarkRunner:
         Args:
             samples: List of audio samples to benchmark.
             service_name: The STT service to use.
+            db: Database; each result is persisted as soon as it is produced
+                (crash-safe) in addition to being returned.
             model: Optional model name override.
             progress_callback: Optional callback(current, total, sample_id).
 
@@ -280,6 +285,8 @@ class BenchmarkRunner:
 
             result = await self.benchmark_sample(sample, service_name, model)
             results.append(result)
+
+            await db.insert_result(result)
 
             # Brief delay between samples to avoid rate limiting
             await asyncio.sleep(0.1)


### PR DESCRIPTION
Write each STT result to the DB as it is produced (pass db into benchmark_batch) instead of one batch insert at the end, so a crash mid-run keeps completed samples. Insert happens between samples, so latency timing is unaffected.